### PR TITLE
Fix bugs in Zorin.sh

### DIFF
--- a/zorin.sh
+++ b/zorin.sh
@@ -106,11 +106,11 @@ fi
 
 # Make sure the temp directory gets removed on script exit.
 trap "exit 1"           HUP INT PIPE QUIT TERM
-trap 'rm -f "$TEMPD"'   EXIT
+trap 'rm -r -f "$TEMPD"'   EXIT
 
 # manually add the keyring
 curl -A 'Zorin OS Premium' https://packages.zorinos.com/premium/pool/main/z/zorin-os-premium-keyring/zorin-os-premium-keyring_1.0_all.deb --output $TEMPD/zorin-os-premium-keyring_1.0_all.deb
-sudo apt install ./zorin-os-premium-keyring_1.0_all.deb
+sudo apt install $TEMPD/zorin-os-premium-keyring_1.0_all.deb
 
 # update packages
 sudo aptitude update ; sudo apt-get update


### PR DESCRIPTION
Pr fixes 2 bugs:

1. The temp directly wasn't deleted after script exits as an -r option is needed to rm
2. The deb downloaded to temp directly wasn't installed correctly as path provided to apt wasn't correct.