### PR TITLE
Update zorin.sh to add initial support for Zorin OS 18 Core Beta

### DIFF
--- a/zorin.sh
+++ b/zorin.sh
@@ -30,9 +30,9 @@ echo "███████╗╚██████╔╝██║  ██║█
 echo "╚══════╝ ╚═════╝ ╚═╝  ╚═╝╚═╝╚═╝  ╚═══╝     ╚═════╝ ╚══════╝    ╚═╝     ╚═╝  ╚═╝ ╚═════╝ "
 echo "|ZORIN-OS-PRO| |Script v9.0.4.3| |Overhauled & Maintained By NamelessNanasi/NanashiTheNameless| |original by kauancvlcnt|"
 echo ""
-echo "(Please note this version ONLY works on Zorin 17 and 16)"
+echo "(Please note this version ONLY works on Zorin 18 Beta, 17 and 16)"
 echo ""
-echo "(to use this script on Zorin 16 add the -6 flag or -7 for zorin 17)"
+echo "(to use this script on Zorin 16 add the -6 flag or -7 for zorin 17 or -8 for zorin 18)"
 echo "(add -X for a lot extra content)"
 echo ""
 echo "THIS CODE AND THE ACCOMPANYING DOCUMENTATION WERE SIGNIFICANTLY OVERHAULED BY NamelessNanashi/NanashiTheNameless."
@@ -59,6 +59,9 @@ while getopts "67XU" opt; do
     ;;
     7)
         version="17"
+    ;;
+    8)
+        version="18"
     ;;
     X)
         extra="true"
@@ -137,12 +140,37 @@ deb-src https://packages.zorinos.com/premium jammy main
 EOF
 }
 
+function AddSources18() {
+sudo \rm -f /etc/apt/sources.list.d/zorin.list
+sudo \touch /etc/apt/sources.list.d/zorin.list
+sudo \tee /etc/apt/sources.list.d/zorin.list > /dev/null << 'EOF'
+deb https://packages.zorinos.com/stable noble main
+deb-src https://packages.zorinos.com/stable noble main
+
+deb https://packages.zorinos.com/patches noble main
+deb-src https://packages.zorinos.com/patches noble main
+
+deb https://packages.zorinos.com/apps noble main
+deb-src https://packages.zorinos.com/apps noble main
+
+deb https://packages.zorinos.com/drivers noble main restricted
+deb-src https://packages.zorinos.com/drivers noble main restricted
+
+deb https://packages.zorinos.com/premium noble main
+deb-src https://packages.zorinos.com/premium noble main
+
+EOF
+}
+
 if [ "$version" = "16" ]; then
     # Add zorin16.list
     AddSources16
 elif [ "$version" = "17" ]; then
     # Add zorin17.list
     AddSources17
+elif [ "$version" = "18" ]; then
+    # Add zorin18.list
+    AddSources18
 else
     fail
 fi
@@ -168,13 +196,13 @@ echo ""
 
 # manually add the keyrings
 curl -H 'DNT: 1' -H 'Sec-GPC: 1' https://ppa.launchpadcontent.net/zorinos/stable/ubuntu/pool/main/z/zorin-os-keyring/zorin-os-keyring_1.1_all.deb --output "$TEMPD/zorin-os-keyring_1.1_all.deb"
-curl -H 'DNT: 1' -H 'Sec-GPC: 1' -A 'Zorin OS Premium' https://packages.zorinos.com/premium/pool/main/z/zorin-os-premium-keyring/zorin-os-premium-keyring_1.0_all.deb --output "$TEMPD/zorin-os-premium-keyring_1.0_all.deb"
+curl -H 'DNT: 1' -H 'Sec-GPC: 1' -A 'Zorin OS Premium' https://packages.zorinos.com/premium/pool/main/z/zorin-os-premium-keyring/zorin-os-premium-keyring_1.1_all.deb --output "$TEMPD/zorin-os-premium-keyring_1.1_all.deb" # for some reason ZorinOS 18 uses keyring v1.1, keyring v1.0 doesn't work
 # fix permissions of manually downloaded keyrings
 sudo chmod 777 "$TEMPD/zorin-os-keyring_1.1_all.deb"
-sudo chmod 777 "$TEMPD/zorin-os-premium-keyring_1.0_all.deb"
+sudo chmod 777 "$TEMPD/zorin-os-premium-keyring_1.1_all.deb"
 sleep 1
 sudo apt install ${apt_no_confirm} "$TEMPD/zorin-os-keyring_1.1_all.deb"
-sudo apt install ${apt_no_confirm} "$TEMPD/zorin-os-premium-keyring_1.0_all.deb"
+sudo apt install ${apt_no_confirm} "$TEMPD/zorin-os-premium-keyring_1.1_all.deb"
 sleep 2
 
 echo ""
@@ -209,6 +237,13 @@ if [ "$version" = "16" ]; then
     fi
 elif [ "$version" = "17" ]; then
     # install 17 pro content
+    if [ "$extra" = "true" ]; then
+        sudo apt-get install ${apt_no_confirm} zorin-additional-drivers-checker zorin-appearance zorin-appearance-layouts-shell-core zorin-appearance-layouts-shell-premium zorin-appearance-layouts-support zorin-auto-theme zorin-connect zorin-desktop-session zorin-desktop-themes zorin-exec-guard zorin-exec-guard-app-db zorin-gnome-tour-autostart zorin-icon-themes zorin-os-artwork zorin-os-default-settings zorin-os-docs zorin-os-file-templates zorin-os-keyring zorin-os-minimal zorin-os-overlay zorin-os-premium-keyring zorin-os-printer-test-page zorin-os-pro zorin-os-pro-creative-suite zorin-os-pro-productivity-apps zorin-os-pro-wallpapers zorin-os-pro-wallpapers-16 zorin-os-pro-wallpapers-17 zorin-os-restricted-addons zorin-os-standard zorin-os-tour-video zorin-os-upgrader zorin-os-wallpapers zorin-os-wallpapers-16 zorin-os-wallpapers-17 zorin-sound-theme zorin-windows-app-support-installation-shortcut
+    else
+        sudo apt-get install ${apt_no_confirm} zorin-appearance zorin-appearance-layouts-shell-core zorin-appearance-layouts-shell-premium zorin-appearance-layouts-support zorin-auto-theme zorin-icon-themes zorin-os-artwork zorin-os-keyring zorin-os-premium-keyring zorin-os-pro zorin-os-pro-wallpapers zorin-os-pro-wallpapers-17 zorin-os-wallpapers zorin-os-wallpapers-17
+    fi
+elif [ "$version" = "18" ]; then
+    # install 18 pro content
     if [ "$extra" = "true" ]; then
         sudo apt-get install ${apt_no_confirm} zorin-additional-drivers-checker zorin-appearance zorin-appearance-layouts-shell-core zorin-appearance-layouts-shell-premium zorin-appearance-layouts-support zorin-auto-theme zorin-connect zorin-desktop-session zorin-desktop-themes zorin-exec-guard zorin-exec-guard-app-db zorin-gnome-tour-autostart zorin-icon-themes zorin-os-artwork zorin-os-default-settings zorin-os-docs zorin-os-file-templates zorin-os-keyring zorin-os-minimal zorin-os-overlay zorin-os-premium-keyring zorin-os-printer-test-page zorin-os-pro zorin-os-pro-creative-suite zorin-os-pro-productivity-apps zorin-os-pro-wallpapers zorin-os-pro-wallpapers-16 zorin-os-pro-wallpapers-17 zorin-os-restricted-addons zorin-os-standard zorin-os-tour-video zorin-os-upgrader zorin-os-wallpapers zorin-os-wallpapers-16 zorin-os-wallpapers-17 zorin-sound-theme zorin-windows-app-support-installation-shortcut
     else


### PR DESCRIPTION
**What This PR Does**
This PR should add initial support for Zorin OS 18 Core Beta.

**Why It's Needed**
Apparently Zorin 18 doesn't permit using the premium keyring v1.0 to download content, requiring v1.1 to be used instead.
I also added the "-8" flag for users to pass into the script on Zorin OS 18.

Apologies if this was done incorrectly, since my bash scripting ability is limited at best.