### PR TITLE
Update zorin.sh to include ZorinOS Pro applications

### DIFF
--- a/zorin.sh
+++ b/zorin.sh
@@ -33,7 +33,7 @@ echo "  ███╔╝ ██║   ██║██████╔╝██║�
 echo " ███╔╝  ██║   ██║██╔══██╗██║██║╚██╗██║    ██║   ██║╚════██║    ██╔═══╝ ██╔══██╗██║   ██║"
 echo "███████╗╚██████╔╝██║  ██║██║██║ ╚████║    ╚██████╔╝███████║    ██║     ██║  ██║╚██████╔╝"
 echo "╚══════╝ ╚═════╝ ╚═╝  ╚═╝╚═╝╚═╝  ╚═══╝     ╚═════╝ ╚══════╝    ╚═╝     ╚═╝  ╚═╝ ╚═════╝ "
-echo "|ZORIN-OS-PRO| |Script v9.3.0.1| |Overhauled & Maintained By NamelessNanasi/NanashiTheNameless| |original idea by kauancvlcnt|"
+echo "|ZORIN-OS-PRO| |Script v9.4.0.0| |Overhauled & Maintained By NamelessNanasi/NanashiTheNameless| |original idea by kauancvlcnt|"
 echo ""
 echo "(Please note this tool ONLY works on ZorinOS 18 Core, ZorinOS 17 Core, and ZorinOS 16 Core)"
 echo ""


### PR DESCRIPTION
Update zorin.sh to include ZorinOS Pro applications from flatpak. sources: https://unix.stackexchange.com/questions/765306/which-applications-are-bundled-with-the-zorin-os-17-pro-distro

https://www.reddit.com/r/zorinos/comments/pqmdxn/zorin_os_pro_16_app_list/

https://forum.zorin.com/t/is-there-a-list-of-pro-applications-for-zorin-pro/44418

https://forum.zorin.com/t/what-are-the-additional-software-shipped-with-zorin-os-pro/32391

https://www.youtube.com/watch?v=Ey6QK_drc1w&t=902s

Note: Currently it installs the same extra apps for all zorinos versions, because I haven't figured out which ones have which applications. It also installs bottles, which I'm not sure if it is really included but I've heard ZorinOS 18 has Windows app support, so I decided to include it. It should have also included virtual box, but that one doesn't have a flatpak for it so I'm not adding it for now